### PR TITLE
Bugfix

### DIFF
--- a/tools/cadutils.py
+++ b/tools/cadutils.py
@@ -35,7 +35,7 @@ def addGeometryToCadLayer(g):
         feat.setGeometry(g)
         pr.addFeatures([feat])
         vl.updateExtents()
-        QgsMapLayerRegistry().instance().addMapLayer(vl, True)
+        QgsMapLayerRegistry.instance().addMapLayer(vl, True)
     else:
         layer = getCadLayerByName(theName) 
         pr = layer.dataProvider()


### PR DESCRIPTION
See: https://github.com/geopython/CadTools/issues/13
Cause: brackets after QgsMapLayerRegistry - this should only be instanced once, however with brackets this is not guarenteed
