### PR TITLE
Replace print statements with QgsMessageLog.logMessage()

### DIFF
--- a/tools/cadconsole.py
+++ b/tools/cadconsole.py
@@ -191,7 +191,7 @@ class CadPythonEdit(QTextEdit):
   def entered(self):
     self.cursor.movePosition(QTextCursor.End, QTextCursor.MoveAnchor)
     self.setTextCursor(self.cursor)
-    print self.currentCommand()
+    QgsMessageLog.logMessage(self.currentCommand(), tag="CadTools", level=QgsMessageLog.INFO)
     self.runCommand( unicode(self.currentCommand()) )
 
   def insertTaggedText(self, txt, tag):

--- a/tools/circulararcdigitizer.py
+++ b/tools/circulararcdigitizer.py
@@ -94,15 +94,15 @@ class CircularArcDigitizer(QgsMapTool):
             if self.mCtrl == True:
                 if self.count == 0:
                     self.ptStart = QgsPoint( point.x(),  point.y() )
-                    print str(self.ptStart.toString())
-                    print "******************** NUmmer EINS...."
+                    QgsMessageLog.logMessage(str(self.ptStart.toString()), tag="CadTools", level=QgsMessageLog.INFO)
+                    QgsMessageLog.logMessage("******************** NUmmer EINS....", tag="CadTools", level=QgsMessageLog.INFO)
                 elif self.count == 1:
                     self.ptArc = QgsPoint( point.x(),  point.y() )
-                    print "******************** NUmmer ZWEI...."
+                    QgsMessageLog.logMessage("******************** NUmmer ZWEI....", tag="CadTools", level=QgsMessageLog.INFO)
                 elif self.count == 2:
                     
-                    print "******************** NUmmer drei...."
-                    print str(self.ptStart.toString())
+                    QgsMessageLog.logMessage("******************** NUmmer drei....", tag="CadTools", level=QgsMessageLog.INFO)
+                    QgsMessageLog.logMessage(str(self.ptStart.toString()), tag="CadTools", level=QgsMessageLog.INFO)
                     
                     self.ptEnd = QgsPoint( point.x(),  point.y() )
                     self.count = -1

--- a/tools/circulararctool.py
+++ b/tools/circulararctool.py
@@ -75,7 +75,7 @@ class CircularArcTool:
         
 
         def unsetTool(self):
-            print "***************** unset tool"  
+            QgsMessageLog.logMessage("***************** unset tool", tag="CadTools", level=QgsMessageLog.INFO)
             self.p1 = None
             self.p2 = None
             self.p3 = None          
@@ -85,7 +85,7 @@ class CircularArcTool:
       
 
         def deactivate(self):
-            print "***************** deactivate circulararctool"            
+            QgsMessageLog.logMessage("***************** deactivate circulararctool", tag="CadTools", level=QgsMessageLog.INFO)
             self.action_selectthreepoints.setChecked(False)   
             
 

--- a/tools/modifycirculararctool.py
+++ b/tools/modifycirculararctool.py
@@ -90,7 +90,7 @@ class ModifyCircularArcTool:
 
 
         def unsetTool(self):
-            print "***************** unset tool modifycirculararctool"  
+            QgsMessageLog.logMessage("***************** unset tool modifycirculararctool", tag="CadTools", level=QgsMessageLog.INFO)
 #            self.p1 = None
 #            self.p2 = None
 #            self.p3 = None          
@@ -100,7 +100,7 @@ class ModifyCircularArcTool:
  
  
         def deactivate(self):
-            print "***************** deactivate modifycirculararctool"            
+            QgsMessageLog.logMessage("***************** deactivate modifycirculararctool", tag="CadTools", level=QgsMessageLog.INFO)
             self.action_modifycirculararc.setChecked(False)   
             
 

--- a/tools/orthogonaltraversegui.py
+++ b/tools/orthogonaltraversegui.py
@@ -121,7 +121,7 @@ class OrthogonalTraverseGui(QDialog, QObject, Ui_OrthogonalTraverse):
         if isValid == 1:
             self.sendTraverse.emit(str(self.lineEditTraverse.text()),  float(self.lineEditStartX.text()),  float(self.lineEditStartY.text()),  float(self.lineEditEndX.text()),  float(self.lineEditEndY.text()), True, False)
             self.adjusted = True
-            print "emitiert...EqlBtn"
+            QgsMessageLog.logMessage("emitiert...EqlBtn", tag="CadTools", level=QgsMessageLog.INFO)
         else:
             return
 
@@ -138,7 +138,7 @@ class OrthogonalTraverseGui(QDialog, QObject, Ui_OrthogonalTraverse):
                     self.sendTraverse.emit(str(self.lineEditTraverse.text()),  float(self.lineEditStartX.text()),  float(self.lineEditStartY.text()),  float(self.lineEditEndX.text()),  float(self.lineEditEndY.text()), True, True)
                 else:
                     self.sendTraverse.emit(str(self.lineEditTraverse.text()),  float(self.lineEditStartX.text()),  float(self.lineEditStartY.text()),  float(self.lineEditEndX.text()),  float(self.lineEditEndY.text()), False, True)
-            print "emitiert...OkBtn"
+            QgsMessageLog.logMessage("emitiert...OkBtn", tag="CadTools", level=QgsMessageLog.INFO)
         else:
             return
         

--- a/tools/orthogonaltraversetool.py
+++ b/tools/orthogonaltraversetool.py
@@ -85,7 +85,7 @@ class OrthogonalTraverseTool:
             
             line = OrthogonalTraverse.traverse(traverse, 0, 1)
             if line == None:
-                print "Line is None!"
+                QgsMessageLog.logMessage("Line is None!", tag="CadTools", level=QgsMessageLog.INFO)
             else:
                 points = line.asPolyline()
                 
@@ -113,7 +113,7 @@ class OrthogonalTraverseTool:
                     rotationAngle = actualAzimuth - referenceAzimuth
                     scale = cadutils.distance(QgsPoint(x1,y1), QgsPoint(x2,y2)) / cadutils.distance(points[0], points[-1])
                     
-                    print str("scale ") + str(scale)
+                    QgsMessageLog.logMessage(str("scale ") + str(scale), tag="CadTools", level=QgsMessageLog.INFO)
                     
                     if adjust == True:
                         lineTransformed = cadutils.helmert2d(line, x1, y1, rotationAngle, scale)

--- a/tools/parallellinetool.py
+++ b/tools/parallellinetool.py
@@ -134,8 +134,8 @@ class ParallelLineTool:
             p2.setX(self.p2.x()) 
             p2.setY( self.p2.y())             
 
-            print str(method)
-            print str(distance)
+            QgsMessageLog.logMessage(str(method), tag="CadTools", level=QgsMessageLog.INFO)
+            QgsMessageLog.logMessage(str(distance), tag="CadTools", level=QgsMessageLog.INFO)
             
             if method == "fixed":
                 g = ParallelLine.calculateLine(self.p1,  self.p2,  distance)
@@ -143,7 +143,7 @@ class ParallelLineTool:
                 self.canvas.refresh()
 
             elif method == "vertex":
-                print "************************888"
+                QgsMessageLog.logMessage("************************888", tag="CadTools", level=QgsMessageLog.INFO)
                 points =  [self.p1,  self.p2]
                 g = QgsGeometry.fromPolyline(points)
                 g.translate( self.pv.x() - self.p1.x(),  self.pv.y() - self.p1.y() )
@@ -157,14 +157,14 @@ class ParallelLineTool:
             self.p2 = p2        
         
         def unsetTool(self):
-            print "***************** unset tool"
+            QgsMessageLog.logMessage("***************** unset tool", tag="CadTools", level=QgsMessageLog.INFO)
             mc = self.canvas
             mc.unsetMapTool(self.tool)      
             self.action_selectline.setChecked(False)       
             
             
         def deactivate(self):
-            print "***************** deactivate parallellinetool"  
+            QgsMessageLog.logMessage("***************** deactivate parallellinetool", tag="CadTools", level=QgsMessageLog.INFO)
             self.dummy = False
             self.rb1.reset()
             self.action_selectline.setChecked(False)       


### PR DESCRIPTION
Closes #22 
Closes #23 
Closes #24 

This pull request replaces all active `print` statements with `QgsMessageLog.logMessage()`.

`logMessage()` takes a message (unchanged from the existing `print` statement), a tag (which allows all messages to be logged to a new tab for CadTools in the Log Messages panel), and a log level (`INFO` in all cases here).

This prevents the random `IOError` that Windows(?) users have reported a few times.