### PR TITLE
Fix #20 - Slow down when editing

### DIFF
--- a/tools/circulararcdigitizertool.py
+++ b/tools/circulararcdigitizertool.py
@@ -58,20 +58,20 @@ class CircularArcDigitizerTool():
                     gtype = layer.geometryType()
                     # Doesn't make sense for points.
                     if gtype <> 0:
-                        if layer.isEditable():
-                            self.action_capturecirculararc.setEnabled(True)
-                            layer.editingStopped.connect(self.toggle)
-                            try:
-                                layer.editingStarted.disconnect(self.toggle)
-                            except TypeError:
-                                pass
-                        else:
-                            self.action_capturecirculararc.setEnabled(False)
-                            layer.editingStarted.connect(self.toggle)
-                            try:
-                                layer.editingStopped.disconnect(self.toggle)
-                            except TypeError:
-                                pass
+                        # enable if editable
+                        self.action_capturecirculararc.setEnabled(layer.isEditable())
+                        try:
+                            layer.editingStarted.disconnect(self.toggle)
+                            # disconnect, will be reconnected
+                        except TypeError:
+                            pass
+                        try:
+                            layer.editingStopped.disconnect(self.toggle)
+                            # when it becomes active layer again
+                        except TypeError:
+                            pass
+                        layer.editingStarted.connect(self.toggle)
+                        layer.editingStopped.connect(self.toggle)
                 
                 
         def deactivate(self):

--- a/tools/horizontalverticaldigitizertool.py
+++ b/tools/horizontalverticaldigitizertool.py
@@ -52,20 +52,20 @@ class HorizontalVerticalDigitizerTool():
                     gtype = layer.geometryType()
                     # Doesn't make sense for Points
                     if gtype <> 0:
-                        if layer.isEditable():
-                            self.act_horivert.setEnabled(True)
-                            layer.editingStopped.connect(self.toggle)
-                            try:
-                                layer.editingStarted.disconnect(self.toggle)
-                            except TypeError:
-                                pass
-                        else:
-                            self.act_horivert.setEnabled(False)
-                            layer.editingStarted.connect(self.toggle)
-                            try:
-                                layer.editingStopped.disconnect(self.toggle)
-                            except TypeError:
-                                pass
+                        # enable if editable
+                        self.act_horivert.setEnabled(layer.isEditable())
+                        try:
+                            layer.editingStarted.disconnect(self.toggle)
+                            # disconnect, will be reconnected
+                        except TypeError:
+                            pass
+                        try:
+                            layer.editingStopped.disconnect(self.toggle)
+                            # when it becomes active layer again
+                        except TypeError:
+                            pass
+                        layer.editingStarted.connect(self.toggle)
+                        layer.editingStopped.connect(self.toggle)
 
 
         def deactivate(self):

--- a/tools/modifycirculararctool.py
+++ b/tools/modifycirculararctool.py
@@ -73,20 +73,20 @@ class ModifyCircularArcTool:
                     gtype = layer.geometryType()
                     ## Does only work for Polylines and MultiPolylines.
                     if gtype == 1:
-                        if layer.isEditable():
-                            self.action_modifycirculararc.setEnabled(True) 
-                            layer.editingStopped.connect(self.toggle)
-                            try:
-                                layer.editingStarted.disconnect(self.toggle)
-                            except TypeError:
-                                pass
-                        else:
-                            self.action_modifycirculararc.setEnabled(False) 
-                            layer.editingStarted.connect(self.toggle)
-                            try:
-                                layer.editingStopped.disconnect(self.toggle)
-                            except TypeError:
-                                pass
+                        # enable if editable
+                        self.action_modifycirculararc.setEnabled(layer.isEditable())
+                        try:
+                            layer.editingStarted.disconnect(self.toggle)
+                            # disconnect, will be reconnected
+                        except TypeError:
+                            pass
+                        try:
+                            layer.editingStopped.disconnect(self.toggle)
+                            # when it becomes active layer again
+                        except TypeError:
+                            pass
+                        layer.editingStarted.connect(self.toggle)
+                        layer.editingStopped.connect(self.toggle)
 
 
         def unsetTool(self):

--- a/tools/orthogonaldigitizertool.py
+++ b/tools/orthogonaldigitizertool.py
@@ -77,20 +77,20 @@ class OrthogonalDigitizerTool():
                     gtype = layer.geometryType()
                     # Doesn't make sense for Points
                     if gtype <> 0:
-                        if layer.isEditable():
-                            self.act_ortho.setEnabled(True)
-                            layer.editingStopped.connect(self.toggle)
-                            try:
-                                layer.editingStarted.disconnect(self.toggle)
-                            except TypeError:
-                                pass
-                        else:
-                            self.act_ortho.setEnabled(False)
-                            layer.editingStarted.connect(self.toggle)
-                            try:
-                                layer.editingStopped.disconnect(self.toggle)
-                            except TypeError:
-                                pass
+                        # enable if editable
+                        self.act_ortho.setEnabled(layer.isEditable())
+                        try:
+                            layer.editingStarted.disconnect(self.toggle)
+                            # disconnect, will be reconnected
+                        except TypeError:
+                            pass
+                        try:
+                            layer.editingStopped.disconnect(self.toggle)
+                            # when it becomes active layer again
+                        except TypeError:
+                            pass
+                        layer.editingStarted.connect(self.toggle)
+                        layer.editingStopped.connect(self.toggle)
 
 
         def deactivate(self):

--- a/tools/splinetool.py
+++ b/tools/splinetool.py
@@ -56,20 +56,20 @@ class SplineTool():
                     gtype = layer.geometryType()
                     # Doesn't make sense for points.
                     if gtype <> 0:
-                        if layer.isEditable():
-                            self.action_spline.setEnabled(True)
-                            layer.editingStopped.connect(self.toggle)
-                            try:
-                                layer.editingStarted.disconnect(self.toggle)
-                            except TypeError:
-                                pass
-                        else:
-                            self.action_spline.setEnabled(False)
-                            layer.editingStarted.connect(self.toggle)
-                            try:
-                                layer.editingStopped.disconnect(self.toggle)
-                            except TypeError:
-                                pass
+                        # enable if editable
+                        self.action_spline.setEnabled(layer.isEditable())
+                        try:
+                            layer.editingStarted.disconnect(self.toggle)
+                            # disconnect, will be reconnected
+                        except TypeError:
+                            pass
+                        try:
+                            layer.editingStopped.disconnect(self.toggle)
+                            # when it becomes active layer again
+                        except TypeError:
+                            pass
+                        layer.editingStarted.connect(self.toggle)
+                        layer.editingStopped.connect(self.toggle)
                 
                 
         def deactivate(self):


### PR DESCRIPTION
Fixes issue #20 by disconnecting signals before connecting them.

The problem is that every time the current layer is changed, `toggle` is called
```
self.iface.currentLayerChanged.connect(self.toggle)
```
Then, the function is attached to the `editingStarted` signal repeatedly
```
layer.editingStarted.connect(self.toggle)
```
(If the layer is in edit mode, the `editingStoppped` signal is being used with the same sequences.)
